### PR TITLE
Avoid writing 10G register when sd_type is FA_SERDES_TYPE_6G

### DIFF
--- a/base/fa/vtss_fa_serdes.c
+++ b/base/fa/vtss_fa_serdes.c
@@ -3665,7 +3665,7 @@ static vtss_rc vtss_fa_sd_board_settings(vtss_state_t *vtss_state, vtss_port_no_
                     VTSS_F_SD25G_TARGET_LANE_03_LN_CFG_TAP_DLY_4_0(value),
                     VTSS_M_SD25G_TARGET_LANE_03_LN_CFG_TAP_DLY_4_0);
 
-        } else {
+        } else if (sd_type == FA_SERDES_TYPE_10G) {
             sd_tgt = VTSS_TO_SD10G_LANE(sd_indx);
             REG_WRM(VTSS_SD10G_LANE_TARGET_LANE_04(sd_tgt),
                     VTSS_F_SD10G_LANE_TARGET_LANE_04_CFG_TAP_DLY_4_0(value),


### PR DESCRIPTION
Avoid writing VTSS_SD10G_LANE_TARGET_LANE_04 register when sd_type is FA_SERDES_TYPE_6G that causes:

E api_cil/port 00:01:00 151/vtss_to_sd10g_lane#49: Error: illegal 10G_lane index 12
Version      : IStaXdev-build by user@59dcf12b34ac 2022-02-15T12:20:13+00:00 Config:istax_sparx_5i_64 Profile:istax_sparx_5i_64 SDK:2021.06-smb
Chip ID      : VSC47558 Rev. B
Board        : pcb134_emmc
Build Date   : 2022-02-15T12:20:13+00:00
Code Revision: aa0ba0a72+
Sched policy = 0
Ticks/sec    = 100
ID  Name                             State Prio         OS Val 1sec Load 10sec Load utime      stime
--- -------------------------------- ----- ------------ ------ --------- ---------- ---------- ----------
  - <Idle task>                      -     -                 -       N/A        N/A          -          -
  - <Other processes/interrupts>     -     -                 -       N/A        N/A          -          -
151 Port Control                     R     Normal            0       N/A        N/A         36          3*
[bt]: (0) /usr/bin/switch_app() [0xa0347c]
[bt]: (1) /usr/bin/switch_app() [0xcf2010]
[bt]: (2) /usr/bin/switch_app() [0xcf485c]
[bt]: (3) /usr/bin/switch_app(mesa_callout_trace_printf+0x50) [0x9ead14]
[bt]: (4) /lib64/libvsc7546TSN.so(vtss_callout_trace_printf+0x60) [0xffffaaf21fb0]
[bt]: (5) /lib64/libvsc7546TSN.so(vtss_to_sd10g_lane+0x6c) [0xffffaadd8a7c]
[bt]: (6) /lib64/libvsc7546TSN.so(vtss_fa_sd_cfg+0x170) [0xffffaade11f0]
[bt]: (7) /lib64/libvsc7546TSN.so(+0xca920) [0xffffaadba920]
[bt]: (8) /lib64/libvsc7546TSN.so(+0xd4640) [0xffffaadc4640]
[bt]: (9) /lib64/libvsc7546TSN.so(vtss_port_conf_set_private+0x14c) [0xffffaad80a7c]
[bt]: (10) /lib64/libvsc7546TSN.so(vtss_port_conf_set+0x1e0) [0xffffaad80cc0]
[bt]: (11) /lib64/libvsc7546TSN.so(mesa_port_conf_set+0x50) [0xffffaaf2d0c0]
[bt]: (12) /usr/bin/switch_app() [0xa9e894]
[bt]: (13) /usr/bin/switch_app() [0xaa2e44]
[bt]: (14) /usr/bin/switch_app() [0xa95cf4]
[bt]: (15) /usr/bin/switch_app() [0xcea828]
[bt]: (16) /lib64/libpthread.so.0(+0x6f48) [0xffffab1b3f48]
[bt]: (17) /lib64/libc.so.6(+0xce29c) [0xffffaaa2929c]
[bt]: (18) [(nil)]