### PR TITLE
mepa: optional config-driven SerDes EQ (host_tx_eq) via the mainstream API

### DIFF
--- a/mepa/include/microchip/ethernet/phy/api/types.h
+++ b/mepa/include/microchip/ethernet/phy/api/types.h
@@ -354,6 +354,22 @@ typedef struct {
 } phy25g_conf_t;
 
 
+/** \brief Optional config-driven SerDes equalizer override (host_tx_eq)  */
+typedef struct {
+    mepa_bool_t apply;        /**< FALSE: driver defaults; TRUE: apply the fields below */
+    mepa_bool_t is_line;      /**< FALSE: host side; TRUE: line side */
+    uint8_t     eq_dir;       /**< equalizer direction: 0=TX, 1=RX, 2=TX+RX */
+    mepa_bool_t dfe_adp_ena;  /**< RX DFE adaptive enable */
+    mepa_bool_t dfe_man_ena;  /**< RX DFE manual enable (unsupported on some ports) */
+    uint8_t     amp_code;     /**< TX amplitude 0..101 (calibrated IPDRIVER+VC_DRIVER) */
+    uint8_t     tx_tap_dly;   /**< TX post-cursor TAP_DLY 0..31 */
+    uint8_t     tx_tap_adv;   /**< TX pre-cursor TAP_ADV 0..15 */
+    uint8_t     rx_vga;       /**< RX VGA 0..31 */
+    uint8_t     rx_ctle_c;    /**< RX CTLE C 0..15 */
+    uint8_t     rx_ctle_r;    /**< RX CTLE R 0..15 */
+} mepa_phy_tx_eq_t;
+
+
 /** \brief Represents the configuration that is applied to PHY. */
 typedef struct {
     mepa_port_speed_t               speed;               /**< Forced port speed */
@@ -369,6 +385,7 @@ typedef struct {
     mepa_cl37_conf_t                cl37_conf;           /**< Clause 37 Configuration for 1000BASE-X for supported PHYs */
     phy10g_conf_t                   conf_10g;
     phy25g_conf_t                   conf_25g;            /**< 25G PHY config structure */
+    mepa_phy_tx_eq_t                host_tx_eq;          /**< Optional SerDes EQ override applied at Dev conf (delegates to lan80xx_phy_tx_rx_equalization_set) */
 } mepa_conf_t;
 
 /** \brief  MEPA event mask */

--- a/mepa/microchip/lan80xx/src/lan80xx_private.c
+++ b/mepa/microchip/lan80xx/src/lan80xx_private.c
@@ -2442,6 +2442,25 @@ mepa_rc lan80xx_serdes_configuration(mepa_device_t *dev, mepa_port_no_t port_no,
     if (lan80xx_serdes_loopback_check(dev, port_no) != MEPA_RC_OK) {
         T_E(MEPA_TRACE_GRP_GEN, "Error in configuring Serdes Loopback on port no : %d\n", port_no);
     }
+
+    /* Optional config-driven SerDes EQ override */
+    if (data->conf.host_tx_eq.apply) {
+        const mepa_phy_tx_eq_t *e = &data->conf.host_tx_eq;
+        phy25g_tx_rx_equa_conf_t equa = {0};
+
+        equa.equalizer_conf = (phy25g_equa_t)e->eq_dir;
+        equa.dfe_adp_ena    = e->dfe_adp_ena;
+        equa.dfe_man_ena    = e->dfe_man_ena;
+        equa.amp_code       = e->amp_code;
+        equa.tx_tap_dly     = e->tx_tap_dly;
+        equa.tx_tap_adv     = e->tx_tap_adv;
+        equa.rx_vga         = e->rx_vga;
+        equa.rx_ctle_c      = e->rx_ctle_c;
+        equa.rx_ctle_r      = e->rx_ctle_r;
+        if (lan80xx_phy_tx_rx_equalization_set_priv(dev, port_no, e->is_line, &equa) != MEPA_RC_OK) {
+            T_E(MEPA_TRACE_GRP_GEN, "host_tx_eq apply failed on port : %d\n", port_no);
+        }
+    }
     return MEPA_RC_OK;
 }
 


### PR DESCRIPTION
Add an optional host_tx_eq block to mepa_conf_t so a board can pin its SerDes equalizer from the conf JSON and have it applied at Dev conf.

The block carries the full scope of lan80xx_phy_tx_rx_equalization_set():
  - side (is_line),
  - direction (eq_dir TX/RX/both),
  - the TX amplitude (amp_code 0..101) + FFE (tx_tap_dly/tx_tap_adv),
  - the RX VGA/CTLE/DFE coefficients.

Note: it is a port of https://github.com/microchip-ung/sw-mepa/pull/14 to mesa.