### PR TITLE
lan80xx: drive the MCU mailbox + DFU without an INTR_A/B GPIO

### DIFF
--- a/.cmake/aggr-artifacts.rb
+++ b/.cmake/aggr-artifacts.rb
@@ -104,7 +104,7 @@ if File.exist? "#{$report_name}"
     run "rm -rf #{$report_name}"
 end
 sys "mkdir #{$report_name}"
-sys "cp -r static_analysis_reports/* #{$report_name}"
+sys "cp -r static_analysis_reports/* #{$report_name}" if File.exist? "static_analysis_reports"
 
 raise "No ws folder" if not File.exist? "./ws"
 

--- a/mepa/microchip/lan80xx/src/lan80xx_private.c
+++ b/mepa/microchip/lan80xx/src/lan80xx_private.c
@@ -6539,6 +6539,22 @@ static mepa_rc lan80xx_MB_SetFlag(const mepa_device_t *dev, uint32_t u32SetMask)
     return rc;
 }
 
+/* Host-interrupt state for the mailbox protocol: from the registered
+ * INTR_A/B GPIO callback when one is wired, else by polling the SPI-readable
+ * mailbox flag register -- so the mailbox and DFU also work on boards where
+ * no INTR_A/B pin is routed to the host. */
+static uint8_t lan80xx_mb_host_intr(const mepa_device_t *dev, phy25g_phy_state_t *base_data, mepa_port_no_t port_no)
+{
+    phy25g_phy_state_t *data = (phy25g_phy_state_t *)dev->data;
+    uint32_t u32Val = 0;
+
+    if (base_data->ft_gpio_read != NULL) {
+        return base_data->ft_gpio_read(dev);
+    }
+    LAN80XX_CSR_RD(dev, port_no, LAN80XX_IOREG(MMD_ID_MCU_MAILBOX, 1, MAILBOX_FLAG_REGISTER), &u32Val);
+    return (u32Val & MAILBOX_HOST_INTR_MASK) ? 1 : 0;
+}
+
 mepa_rc lan80xx_MB_SendRequest(const mepa_device_t *dev, uint8_t *au8CmdPkt, uint16_t u16DataLen)
 {
     mepa_rc rc = MEPA_RC_OK;
@@ -6577,11 +6593,7 @@ mepa_rc lan80xx_MB_SendRequest(const mepa_device_t *dev, uint8_t *au8CmdPkt, uin
         u16DataLen -= SPI_VAL_LEN;
     }
     T_D(MEPA_TRACE_GRP_GEN, "Pkt written, checking MCU busy status...\n");
-    uint8_t u8McuInterrupt = 1;
-
-    if (base_data->ft_gpio_read) {
-        u8McuInterrupt = base_data->ft_gpio_read(dev);
-    }
+    uint8_t u8McuInterrupt = lan80xx_mb_host_intr(dev, base_data, port_no);
     uint32_t u32Val = 0;
     if (1 == u8McuInterrupt) {
         /*
@@ -6643,9 +6655,7 @@ mepa_rc lan80xx_MB_ReadResponse(const mepa_device_t *dev, uint8_t *u8ResponsePkt
 
     T_D (MEPA_TRACE_GRP_GEN, "Waiting for HOST interrupt...");
     while (1) {
-        if (base_data->ft_gpio_read) {
-            u8McuInterrupt = base_data->ft_gpio_read(dev);
-        }
+        u8McuInterrupt = lan80xx_mb_host_intr(dev, base_data, port_no);
         /*
          * If interrupt is set, then make sure HOST interrupt is set before reading response
          */
@@ -7104,6 +7114,14 @@ mepa_rc lan80xx_fw_update_priv(mepa_device_t *dev)
     if (rc != MEPA_RC_OK) {
         T_E(MEPA_TRACE_GRP_GEN, "mailbox init failed\n");
         return rc;
+    }
+    /* If no INTR_A/B pin is wired, the waits below fall back to reading the
+     * SPI-visible mailbox flag register (assume-asserted + flag check), the
+     * same fallback used by MB_SendRequest/MB_ReadResponse via
+     * lan80xx_mb_host_intr(). Do NOT abort DFU when ft_gpio_read is
+     * unregistered. */
+    if (base_data->ft_gpio_read == NULL) {
+        T_IM(data->port_no, "No INTR_A/B callback; using SPI-flag polling for DFU\n");
     }
     T_IM(data->port_no,"Waiting for First packet interrupt...\n");
     // Wait for DFU first packet Interrupt


### PR DESCRIPTION
The mailbox handshake (MB_SendRequest/MB_ReadResponse) and the DFU firmware update gated on a registered ft_gpio_read callback that reads the INTR_A/B pin. On boards where that pin is not routed to a readable host GPIO and there is no MESA switch (e.g. a LAN80xx hung directly off an SoC over SPI in PHY-only mode) no callback is registered, so the mailbox and DFU aborted with "INTR_A/B callback not registered!".

Add lan80xx_mb_host_intr(): when no callback is registered, poll the host-interrupt condition over SPI from MAILBOX_FLAG_REGISTER bit1 (MAILBOX_HOST_INTR_MASK). The same flag the mailbox code re-reads immediately after the gate. Fall back to the registered callback whenever one is present, so EDSx behaviour is unchanged. Use it in MB_SendRequest, MB_ReadResponse and the DFU first-packet wait, and stop aborting DFU when no callback is registered.