### PR TITLE
utils: lm_utils_pp: __VA_OPT__ arg-count path for any GCC >= 13

### DIFF
--- a/utils/include/lm_utils_pp.h
+++ b/utils/include/lm_utils_pp.h
@@ -27,7 +27,7 @@
     N
 
 #if defined(__GNUC__)
-#if __GNUC__ == 13
+#if __GNUC__ >= 13
 // Not sure when it is best to use __VA_OPT__(,) instead of ##__VA_ARGS__, but
 // we see that gcc 13 does not shallow the comma in the MACROs below.
 // But we cannot change to always __VA_OPT__(,) as this is not supported in


### PR DESCRIPTION
The empty-__VA_ARGS__ argument counter has two implementations: a __VA_OPT__(,) variant (correct when the compiler does not swallow the comma after ##__VA_ARGS__) and a legacy ##__VA_ARGS__ variant.

Since __GNUC__ >= 13; __VA_OPT__ is available on every GCC.