### PR TITLE
build: avoid format-security and unused-result from -Werror

### DIFF
--- a/.cmake/flags.cmake
+++ b/.cmake/flags.cmake
@@ -12,6 +12,9 @@ string (REPLACE " -" ";-" EXE_LINKER_FLAGS      "${CMAKE_EXE_LINKER_FLAGS}")
 
 LIST(APPEND C_FLAGS   "-Wall -Werror -Wno-unknown-pragmas -Wno-array-bounds -Wno-stringop-overflow -Wno-nonnull -fasynchronous-unwind-tables -std=c11 -D_POSIX_C_SOURCE=200809L -D_BSD_SOURCE -D_DEFAULT_SOURCE -ldl")
 
+LIST(APPEND C_FLAGS   "-Wno-error=format-security")
+LIST(APPEND C_FLAGS   "-Wno-error=unused-result")
+
 # This is always set by buildroot - not sure why
 LIST(REMOVE_ITEM C_FLAGS   "-Os")
 LIST(REMOVE_ITEM C_FLAGS   "-DNDEBUG")


### PR DESCRIPTION
Newer toolchains (GCC >= 15 at least) and distro hardening are too restrictive.

It fixes issues such as:
  base/ail/vtss_api.c: error: format not a string literal and no format
    arguments [-Werror=format-security]
    (prntf(buf) on a runtime, non-user-controlled string)

  mesa/demo/mepa_apps/phy_gpio_demo.c: error: ignoring return value of
    'scanf' declared with attribute 'warn_unused_result'
    [-Werror=unused-result]